### PR TITLE
Feature/handle dynamic non translated sitemap

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     }
   ],
   "require": {
-    "laravel/framework": ">=11.0"
+    "laravel/framework": ">=9.0"
   },
   "require-dev": {
     "orchestra/testbench": "^7.0@dev"

--- a/src/Contracts/SitemapContract.php
+++ b/src/Contracts/SitemapContract.php
@@ -4,5 +4,7 @@ namespace SolutionPlus\Sitemap\Contracts;
 
 interface SitemapContract
 {
-    public static function dynamicSitemap(): array;
+    public static function sitemapTranslatedSegments(): array;
+    
+    public static function buildSitemapUrls(): array;
 }

--- a/src/Helpers/GenerateSitemapHelper.php
+++ b/src/Helpers/GenerateSitemapHelper.php
@@ -15,8 +15,8 @@ class GenerateSitemapHelper
         $dynamicUrls = [];
 
         foreach (config('sitemap.dynamic_links') as $modelClass):
-            if (\method_exists($modelClass, 'dynamicSitemap')) {
-                $modelUrls = $modelClass::dynamicSitemap();
+            if (\method_exists($modelClass, 'buildSitemapUrls')) {
+                $modelUrls = $modelClass::buildSitemapUrls();
 
                 $dynamicUrls = array_merge($dynamicUrls, $modelUrls);
             }
@@ -26,7 +26,7 @@ class GenerateSitemapHelper
 
         $xml = self::buildXml($urls);
 
-        $filePath = self::getSitemapFilePath();
+        $filePath = SitemapHelperFunctions::getSitemapFilePath();
 
         return Storage::disk('public')->put($filePath, $xml);
     }
@@ -109,12 +109,5 @@ class GenerateSitemapHelper
         }
 
         return $websiteUrl;
-    }
-
-    public static function getSitemapFilePath(): string
-    {
-        $fileName =  config('sitemap.subdomain') ? config('sitemap.subdomain') . '-sitemap.xml' : 'sitemap.xml';
-
-        return 'sitemaps\\' . $fileName;
     }
 }

--- a/src/Helpers/HandleDynamicSitemapHelper.php
+++ b/src/Helpers/HandleDynamicSitemapHelper.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Collection;
 
 class HandleDynamicSitemapHelper
 {
-    public static function handleTranslations(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug')
+    public static function handleTranslations(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
     {
         $urls = [];
 
@@ -54,7 +54,49 @@ class HandleDynamicSitemapHelper
                     'loc' => $locale . '/' . $segment . '/' . $slug,
                     'other_locs' => [],
                     'alternates' => $alternates,
-                    'priority' => '0.9',
+                    'priority' => $priority,
+                ];
+            }
+        }
+
+        return $urls;
+    }
+
+    public static function handleNonTranslations(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
+    {
+        $urls = [];
+        $defaultLocale = config('sitemap.default_locale');
+        $locales = config('translatable.locales');
+
+        foreach ($modelItems as $modelItem) {
+            $routeValue = $modelItem->{$routeKeyName}; // this is constant across locales
+
+            foreach ($locales as $locale) {
+                $segment = $translatedSegments[$locale] ?? $translatedSegments[$defaultLocale];
+
+                $alternates = [];
+
+                foreach ($locales as $altLocale) {
+                    $altSegment = $translatedSegments[$altLocale] ?? $translatedSegments[$defaultLocale];
+
+                    $alternates[] = [
+                        'hreflang' => $altLocale,
+                        'href' => $altLocale . '/' . $altSegment . '/' . $routeValue,
+                    ];
+                }
+
+                // Add x-default
+                $xDefaultSegment = $translatedSegments[$defaultLocale];
+                $alternates[] = [
+                    'hreflang' => 'x-default',
+                    'href' => $xDefaultSegment . '/' . $routeValue,
+                ];
+
+                $urls[] = [
+                    'loc' => $locale . '/' . $segment . '/' . $routeValue,
+                    'other_locs' => [],
+                    'alternates' => $alternates,
+                    'priority' => $priority,
                 ];
             }
         }

--- a/src/Helpers/HandleDynamicSitemapHelper.php
+++ b/src/Helpers/HandleDynamicSitemapHelper.php
@@ -6,10 +6,10 @@ use Illuminate\Database\Eloquent\Collection;
 
 class HandleDynamicSitemapHelper
 {
-    public static function handleTranslations(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
+    public static function buildLocalizedUrls(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
     {
         $urls = [];
-
+        
         $defaultLocale = config('sitemap.default_locale');
 
         $locales = config('translatable.locales');
@@ -62,7 +62,7 @@ class HandleDynamicSitemapHelper
         return $urls;
     }
 
-    public static function handleNonTranslations(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
+    public static function buildDefaultUrls(Collection $modelItems, array $translatedSegments, $routeKeyName = 'slug', $priority = 0.8): array
     {
         $urls = [];
         $defaultLocale = config('sitemap.default_locale');

--- a/src/Helpers/SitemapHelperFunctions.php
+++ b/src/Helpers/SitemapHelperFunctions.php
@@ -1,1 +1,13 @@
 <?php
+
+namespace SolutionPlus\Sitemap\Helpers;
+
+class SitemapHelperFunctions
+{
+    public static function getSitemapFilePath(): string
+    {
+        $fileName =  config('sitemap.subdomain') ? config('sitemap.subdomain') . '-sitemap.xml' : 'sitemap.xml';
+
+        return 'sitemaps\\' . $fileName;
+    }
+}

--- a/src/Helpers/SitemapHelperFunctions.php
+++ b/src/Helpers/SitemapHelperFunctions.php
@@ -8,6 +8,6 @@ class SitemapHelperFunctions
     {
         $fileName =  config('sitemap.subdomain') ? config('sitemap.subdomain') . '-sitemap.xml' : 'sitemap.xml';
 
-        return 'sitemaps\\' . $fileName;
+        return 'sitemaps/' . $fileName;
     }
 }

--- a/src/Http/Controllers/Website/SitemapController.php
+++ b/src/Http/Controllers/Website/SitemapController.php
@@ -2,15 +2,15 @@
 
 namespace SolutionPlus\Sitemap\Http\Controllers\Website;
 
-use SolutionPlus\Sitemap\Helpers\GenerateSitemapHelper;
-use SolutionPlus\Sitemap\Http\Controllers\Controller;
 use Illuminate\Support\Facades\Storage;
+use SolutionPlus\Sitemap\Http\Controllers\Controller;
+use SolutionPlus\Sitemap\Helpers\SitemapHelperFunctions;
 
 class SitemapController extends Controller
 {
     public function __invoke()
     {
-        $filePath = GenerateSitemapHelper::getSitemapFilePath();
+        $filePath = SitemapHelperFunctions::getSitemapFilePath();
 
         $xml = Storage::disk('public')->get($filePath);
 

--- a/src/Http/Controllers/Website/SitemapController.php
+++ b/src/Http/Controllers/Website/SitemapController.php
@@ -14,8 +14,6 @@ class SitemapController extends Controller
 
         $xml = Storage::disk('public')->get($filePath);
 
-        return response([
-            'sitemap' => $xml,
-        ]);
+        return response($xml);
     }
 }

--- a/src/SitemapServiceProvider.php
+++ b/src/SitemapServiceProvider.php
@@ -2,7 +2,6 @@
 
 namespace SolutionPlus\Sitemap;
 
-use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 use SolutionPlus\Sitemap\Console\Commands\GenerateSitemapCommand;

--- a/src/config/sitemap.php
+++ b/src/config/sitemap.php
@@ -76,16 +76,16 @@ return [
     | is provided in the commented section below.
     */
     'static_links' => [
-//        [
-//            'loc' => 'ar',
-//            'other_locs' => ['en'],
-//            'alternates' => [
-//                ['hreflang' => 'ar', 'href' => 'ar'],
-//                ['hreflang' => 'en', 'href' => 'en'],
-//                ['hreflang' => 'x-default', 'href' => ''],
-//            ],
-//            'priority' => '1.0',
-//        ],
+        // [
+        //     'loc' => 'ar',
+        //     'other_locs' => ['en'],
+        //     'alternates' => [
+        //         ['hreflang' => 'ar', 'href' => 'ar'],
+        //         ['hreflang' => 'en', 'href' => 'en'],
+        //         ['hreflang' => 'x-default', 'href' => ''],
+        //     ],
+        //     'priority' => '1.0',
+        // ],
     ],
 
     /*
@@ -98,7 +98,7 @@ return [
     | provide required methods for link generation.
     */
     'dynamic_links' => [
-//        App\Models\Example::class,
+        // App\Models\Example::class,
     ],
 
     /*


### PR DESCRIPTION
- Rename methods for better understanding.
- add implementation for SitemapHelperFunctions file.
- rename the contact methods.
- add buildDefaultUrls method to build dynamic sitemap for models that don`t have a translated route name.
- change the controller response structure form json to xml